### PR TITLE
Update E0V1E.py

### DIFF
--- a/binance/E0V1E.py
+++ b/binance/E0V1E.py
@@ -4,7 +4,7 @@ import pandas_ta as pta
 from freqtrade.persistence import Trade
 from freqtrade.strategy.interface import IStrategy
 from pandas import DataFrame
-from freqtrade.strategy import DecimalParameter, IntParameter
+from freqtrade.strategy import DecimalParameter, IntParameter, informative
 from functools import reduce
 import warnings
 


### PR DESCRIPTION
Fix missing informative error. However when using the newest version of Freqtrade the following error will be generated when running this code:

```
Informative timeframe must be equal or higher than strategy timeframe
```